### PR TITLE
Hatena Blogのリンク修正、READMEのリンク表記修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@
 
 hugo-bloxというhugo themeの[Hugo Landing Page Theme](https://github.com/HugoBlox/theme-landing-page) を使っています。
 
-- [💻 Edit your Hugo site locally | Hugo Blox Docs https://docs.hugoblox.com/getting-started/install-hugo/] などを参考に `hugo` をインストールしてください
+- [💻 Edit your Hugo site locally | Hugo Blox Docs](https://docs.hugoblox.com/getting-started/install-hugo/) などを参考に `hugo` をインストールしてください
 - `hugo server -D`

--- a/content/_index.md
+++ b/content/_index.md
@@ -20,7 +20,7 @@ sections:
           padding: 10px
         - name: Hatena Blog
           icon: custom/hatenablog
-          href: "https://hatenablog.com"
+          href: "https://blog.fp-matsuri.org/"
     design:
       spacing:
         padding: [0, 0, 0, 0]


### PR DESCRIPTION
はてなブログのリンクを以下に修正しました。

https://blog.fp-matsuri.org/


またREADMEのリンクの表記を正しくしました。