### PR TITLE
セッション募集・結果発表のリンク・日時を追加

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -60,8 +60,8 @@ sections:
     content:
       title: Schedule
       schedule:
-        - event: セッション応募開始
-          at: 2025年初め
+        - event: '[セッション応募開始](https://fortee.jp/2025fp-matsuri/speaker/proposal/cfp)'
+          at: 2025年1月20日
         - event: セッション採択結果発表
           at: 
         - event: チケット販売開始

--- a/content/_index.md
+++ b/content/_index.md
@@ -63,7 +63,7 @@ sections:
         - event: '[セッション応募開始](https://fortee.jp/2025fp-matsuri/speaker/proposal/cfp)'
           at: 2025年1月20日
         - event: セッション採択結果発表
-          at: 
+          at: 2025年3月中
         - event: チケット販売開始
           at: 2025年春頃
         - event: 関数型まつり開催

--- a/hugo-blox/blox/community/schedule.html
+++ b/hugo-blox/blox/community/schedule.html
@@ -24,7 +24,7 @@
           <div class="flex items-center" style="margin:2px 0; height:var(--row-height);">
             <div class="rounded-full" style="margin-left:2px; width:var(--point-size); height:var(--point-size); background:rgba(var(--color-on-primary))"></div>
             <div class="pl-4" style="margin-left: var(--content-margin)">
-              <div class="{{ if .highlight }}text-3xl{{else}}text-lg{{end}} font-bold">{{ .event }}</div>
+              <div class="{{ if .highlight }}text-3xl{{else}}text-lg{{end}} font-bold">{{ .event | markdownify }}</div>
               <div class="text-sm">{{ .at }}</div>
             </div>
           </div>


### PR DESCRIPTION
1/20より開始されているセッション募集の内容を反映した。

## 変更点

- トップページにセッション応募開始のリンクと日時を追加 
- トップページにセッション採択結果発表の予定を追加

## スクショ

![image](https://github.com/user-attachments/assets/13292098-7b49-4a10-a14c-fa48b958d072)
