### PR TITLE
Markdown styles

### DIFF
--- a/app/Route/Index.elm
+++ b/app/Route/Index.elm
@@ -127,7 +127,7 @@ links =
 aboutBlock : Html msg
 aboutBlock =
     block "About"
-        [ div []
+        [ div [ class "markdown" ]
             [ p [] [ text "関数型プログラミングのカンファレンス「関数型まつり」を開催します！" ]
             , p []
                 [ text "関数型プログラミングはメジャーな言語・フレームワークに取り入れられ、広く使われるようになりました。"
@@ -152,7 +152,7 @@ overviewBlock =
                 ]
     in
     block "Overview"
-        [ div [ class "prose" ]
+        [ div [ class "markdown prose" ]
             [ item "Dates"
                 "2025.6.14(土)〜15(日)"
             , item "Place"
@@ -227,7 +227,7 @@ schedule =
 sponsorsBlock : Html msg
 sponsorsBlock =
     block "Sponsors"
-        [ div [ class "sponsors" ]
+        [ div [ class "markdown sponsors" ]
             [ h3 [ class "text-3xl font-bold text-center py-8" ] [ text "スポンサー募集中！" ]
             , p []
                 [ text "関数型まつりの開催には、みなさまのサポートが必要です！現在、イベントを支援していただけるスポンサー企業を募集しています。関数型プログラミングのコミュニティを一緒に盛り上げていきたいという企業のみなさま、ぜひご検討ください。"

--- a/app/Route/Slug_.elm
+++ b/app/Route/Slug_.elm
@@ -164,7 +164,7 @@ view app _ =
     { title = metadata.title
     , body =
         [ section [ class "coc" ]
-            [ div []
+            [ div [ class "markdown" ]
                 (app.data.body
                     |> Markdown.Renderer.render customizedHtmlRenderer
                     |> Result.withDefault []

--- a/style.css
+++ b/style.css
@@ -136,13 +136,6 @@ section {
   row-gap: 2.25rem;
 }
 
-section p {
-  line-height: 1.75;
-}
-
-section>* {
-  max-width: 65ch;
-}
 
 section>h2 {
   margin: 0;
@@ -267,6 +260,8 @@ section>h2 {
 .prose h3 {
   margin-top: 1.6em;
   margin-bottom: 0.6em;
+  font-family: "Hiragino Mincho ProN W6", "ヒラギノ明朝 ProN W6", "Hiragino Mincho ProN", "游明朝", YuMincho, "HG明朝E", "ＭＳ Ｐ明朝", "ＭＳ 明朝", serif;
+  font-weight: bold;
 }
 
 .map {
@@ -359,10 +354,6 @@ li.event>p {
 
 .sponsors p {
   margin-block: 1.25rem;
-}
-
-.people {
-  max-width: none;
 }
 
 .people>h3 {

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 
 :root {
   font-size: 12pt;
-  font-family: "游明朝", "Yu Mincho", "游明朝体", "YuMincho", "ヒラギノ明朝 Pro W3", "Hiragino Mincho Pro", "HiraMinProN-W3", "HGS明朝E", "ＭＳ Ｐ明朝", "MS PMincho", serif;
+  font-family: "Hiragino Mincho ProN W3", "ヒラギノ明朝 ProN W3", "Hiragino Mincho ProN", "游明朝", YuMincho, "HG明朝E", "ＭＳ Ｐ明朝", "ＭＳ 明朝", serif;
 
   --navbar-height: 72px;
 
@@ -45,6 +45,7 @@ body {
 
 .site-header>h1>a {
   display: block;
+  font-family: "游明朝", "Yu Mincho", "游明朝体", "YuMincho", "ヒラギノ明朝 Pro W3", "Hiragino Mincho Pro", "HiraMinProN-W3", "HGS明朝E", "ＭＳ Ｐ明朝", "MS PMincho", serif;
   font-size: 1.25rem;
   font-weight: 600;
   text-decoration: inherit;
@@ -163,6 +164,7 @@ section>h2 {
   grid-row: 2;
   margin: 0;
   line-height: 1;
+  font-family: "游明朝", "Yu Mincho", "游明朝体", "YuMincho", "ヒラギノ明朝 Pro W3", "Hiragino Mincho Pro", "HiraMinProN-W3", "HGS明朝E", "ＭＳ Ｐ明朝", "MS PMincho", serif;
   font-size: 3rem;
   font-weight: inherit;
   letter-spacing: -0.25rem;

--- a/style.css
+++ b/style.css
@@ -354,6 +354,17 @@ li.event>p {
 /* ------------------------------------
 Markdown
 ------------------------------------ */
+
+.markdown {
+  max-width: 32.5em;
+
+  /*
+    2024年に最適なfont-familyの書き方
+    https://ics.media/entry/200317/
+  */
+  font-family: "Helvetica Neue", Arial, "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif;
+}
+
 .markdown>* {
   margin-block: 1.75em;
 }
@@ -364,11 +375,17 @@ Markdown
 
 .markdown h2 {
   margin: 7rem 0 2.5rem;
-  font-family: montserrat, sans-serif;
   line-height: 1;
   text-align: center;
   font-size: 2rem;
-  font-weight: bold;
+  font-weight: normal;
+}
+
+.markdown p,
+.markdown ul {
+  font-family: "Hiragino Mincho ProN W3", "ヒラギノ明朝 ProN W3", "Hiragino Mincho ProN", "游明朝", YuMincho, "HG明朝E", "ＭＳ Ｐ明朝", "ＭＳ 明朝", serif;
+  letter-spacing: 0.01em;
+  line-height: 1.75;
 }
 
 .markdown li {
@@ -412,13 +429,10 @@ section.coc {
   translate: -2em;
   margin-inline: 0;
   background-color: #F1F1F1;
-  line-height: 1.75;
   font-size: 16px;
-  letter-spacing: 0.05em;
   padding: 2em;
   border-radius: 10px;
 }
-
 
 .markdown ul {
   padding: 2em 2em 2em 55px;

--- a/style.css
+++ b/style.css
@@ -1,14 +1,21 @@
 @import url('https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap');
 
 :root {
-  font-size: 12pt;
-  font-family: "Hiragino Mincho ProN W3", "ヒラギノ明朝 ProN W3", "Hiragino Mincho ProN", "游明朝", YuMincho, "HG明朝E", "ＭＳ Ｐ明朝", "ＭＳ 明朝", serif;
-
   --navbar-height: 72px;
+
+  --serif-W3: "Hiragino Mincho ProN W3", "ヒラギノ明朝 ProN W3", "Hiragino Mincho ProN", "游明朝", YuMincho, "HG明朝E", "ＭＳ Ｐ明朝", "ＭＳ 明朝", serif;
+  --serif-W6: "Hiragino Mincho ProN W6", "ヒラギノ明朝 ProN W6", "Hiragino Mincho ProN", "游明朝", YuMincho, "HG明朝E", "ＭＳ Ｐ明朝", "ＭＳ 明朝", serif;
+  --serif-logo: "游明朝", "Yu Mincho", "游明朝体", "YuMincho", "ヒラギノ明朝 Pro W3", "Hiragino Mincho Pro", "HiraMinProN-W3", "HGS明朝E", "ＭＳ Ｐ明朝", "MS PMincho", serif;
+
+  /* [2024年に最適なfont-familyの書き方](https://ics.media/entry/200317/) */
+  --sans-serif-W3: "Helvetica Neue", Arial, "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif;
 
   --color-primary: 16 40 48;
   --color-on-primary: 240 240 230;
   --color-accent: 233 30 99;
+
+  font-size: 12pt;
+  font-family: var(--serif-W3);
 }
 
 * {
@@ -45,7 +52,7 @@ body {
 
 .site-header>h1>a {
   display: block;
-  font-family: "游明朝", "Yu Mincho", "游明朝体", "YuMincho", "ヒラギノ明朝 Pro W3", "Hiragino Mincho Pro", "HiraMinProN-W3", "HGS明朝E", "ＭＳ Ｐ明朝", "MS PMincho", serif;
+  font-family: var(--serif-logo);
   font-size: 1.25rem;
   font-weight: 600;
   text-decoration: inherit;
@@ -72,12 +79,7 @@ Markdown
 
 .markdown {
   max-width: 32.5em;
-
-  /*
-    2024年に最適なfont-familyの書き方
-    https://ics.media/entry/200317/
-  */
-  font-family: "Helvetica Neue", Arial, "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif;
+  font-family: var(--sans-serif-W3);
 }
 
 .markdown>* {
@@ -98,7 +100,7 @@ Markdown
 
 .markdown p,
 .markdown ul {
-  font-family: "Hiragino Mincho ProN W3", "ヒラギノ明朝 ProN W3", "Hiragino Mincho ProN", "游明朝", YuMincho, "HG明朝E", "ＭＳ Ｐ明朝", "ＭＳ 明朝", serif;
+  font-family: var(--serif-W3);
   letter-spacing: 0.01em;
   line-height: 1.75;
 }
@@ -164,7 +166,7 @@ section>h2 {
   grid-row: 2;
   margin: 0;
   line-height: 1;
-  font-family: "游明朝", "Yu Mincho", "游明朝体", "YuMincho", "ヒラギノ明朝 Pro W3", "Hiragino Mincho Pro", "HiraMinProN-W3", "HGS明朝E", "ＭＳ Ｐ明朝", "MS PMincho", serif;
+  font-family: var(--serif-logo);
   font-size: 3rem;
   font-weight: inherit;
   letter-spacing: -0.25rem;
@@ -262,7 +264,7 @@ section>h2 {
 .prose h3 {
   margin-top: 1.6em;
   margin-bottom: 0.6em;
-  font-family: "Hiragino Mincho ProN W6", "ヒラギノ明朝 ProN W6", "Hiragino Mincho ProN", "游明朝", YuMincho, "HG明朝E", "ＭＳ Ｐ明朝", "ＭＳ 明朝", serif;
+  font-family: var(--serif-W6);
 }
 
 .map {
@@ -346,7 +348,7 @@ li.event>p {
 .sponsors h3 {
   margin: 0;
   padding-block: 2rem 0.5rem;
-  font-family: "Hiragino Mincho ProN W3", "ヒラギノ明朝 ProN W3", "Hiragino Mincho ProN", "游明朝", YuMincho, "HG明朝E", "ＭＳ Ｐ明朝", "ＭＳ 明朝", serif;
+  font-family: var(--serif-W3);
   text-align: center;
   line-height: 2.25rem;
   font-size: 1.875rem;
@@ -358,7 +360,7 @@ li.event>p {
 
 .people>h3 {
   text-align: center;
-  font-family: "Hiragino Mincho ProN W6", "ヒラギノ明朝 ProN W6", "Hiragino Mincho ProN", "游明朝", YuMincho, "HG明朝E", "ＭＳ Ｐ明朝", "ＭＳ 明朝", serif;
+  font-family: var(--serif-W6);
 }
 
 .people ul {

--- a/style.css
+++ b/style.css
@@ -352,30 +352,30 @@ li.event>p {
 }
 
 /* ------------------------------------
-行動規範
+Markdown
 ------------------------------------ */
 
 section.coc {
   padding-block: 3rem;
 }
 
-section.coc h2 {
-  margin: 0 0 2.5rem;
-  font-family: montserrat, sans-serif;
-  font-optical-sizing: auto;
-  line-height: 1;
-  text-align: center;
-  font-size: 3rem;
-  font-weight: 300;
-}
-
-section.coc *+h2 {
-  margin-top: 8rem;
-}
-
-section.coc p+p {
+.markdown>* {
   margin-block: 1.75em;
 }
+
+.markdown>:first-child {
+  margin-block: 0;
+}
+
+.markdown h2 {
+  margin: 7rem 0 2.5rem;
+  font-family: montserrat, sans-serif;
+  line-height: 1;
+  text-align: center;
+  font-size: 2rem;
+  font-weight: bold;
+}
+
 
 .section_figure {
   margin-inline: 0;
@@ -390,8 +390,8 @@ section.coc p+p {
   font-weight: bold;
 }
 
-section.coc ul,
-section.coc blockquote,
+.markdown ul,
+.markdown blockquote,
 .section_note {
   margin-inline: 0;
   background-color: #F1F1F1;
@@ -400,17 +400,16 @@ section.coc blockquote,
   font-size: 16px;
   letter-spacing: 0.1em;
   padding: 40px;
-  margin-top: 20px;
 }
 
-section.coc li {
+.markdown li {
   padding-left: 22px;
   position: relative;
   margin-bottom: 5px;
   list-style: none;
 }
 
-section.coc li::before {
+.markdown li::before {
   content: "";
   display: block;
   width: 6px;

--- a/style.css
+++ b/style.css
@@ -66,6 +66,55 @@ body {
 }
 
 /* ------------------------------------
+Markdown
+------------------------------------ */
+
+.markdown {
+  max-width: 32.5em;
+
+  /*
+    2024年に最適なfont-familyの書き方
+    https://ics.media/entry/200317/
+  */
+  font-family: "Helvetica Neue", Arial, "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif;
+}
+
+.markdown>* {
+  margin-block: 1.75em;
+}
+
+.markdown>:first-child {
+  margin-block: 0;
+}
+
+.markdown h2 {
+  margin: 7rem 0 2.5rem;
+  line-height: 1;
+  text-align: center;
+  font-size: 2rem;
+  font-weight: normal;
+}
+
+.markdown p,
+.markdown ul {
+  font-family: "Hiragino Mincho ProN W3", "ヒラギノ明朝 ProN W3", "Hiragino Mincho ProN", "游明朝", YuMincho, "HG明朝E", "ＭＳ Ｐ明朝", "ＭＳ 明朝", serif;
+  letter-spacing: 0.01em;
+  line-height: 1.75;
+}
+
+.markdown li {
+  padding-left: 0.3em;
+}
+
+.markdown li+li {
+  margin-top: 0.25em;
+}
+
+.markdown li::marker {
+  font-size: 1.4em;
+}
+
+/* ------------------------------------
 トップページ
 ------------------------------------ */
 
@@ -349,55 +398,6 @@ li.event>p {
   font-weight: bold;
   color: inherit;
   text-decoration: none;
-}
-
-/* ------------------------------------
-Markdown
------------------------------------- */
-
-.markdown {
-  max-width: 32.5em;
-
-  /*
-    2024年に最適なfont-familyの書き方
-    https://ics.media/entry/200317/
-  */
-  font-family: "Helvetica Neue", Arial, "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif;
-}
-
-.markdown>* {
-  margin-block: 1.75em;
-}
-
-.markdown>:first-child {
-  margin-block: 0;
-}
-
-.markdown h2 {
-  margin: 7rem 0 2.5rem;
-  line-height: 1;
-  text-align: center;
-  font-size: 2rem;
-  font-weight: normal;
-}
-
-.markdown p,
-.markdown ul {
-  font-family: "Hiragino Mincho ProN W3", "ヒラギノ明朝 ProN W3", "Hiragino Mincho ProN", "游明朝", YuMincho, "HG明朝E", "ＭＳ Ｐ明朝", "ＭＳ 明朝", serif;
-  letter-spacing: 0.01em;
-  line-height: 1.75;
-}
-
-.markdown li {
-  padding-left: 0.3em;
-}
-
-.markdown li+li {
-  margin-top: 0.25em;
-}
-
-.markdown li::marker {
-  font-size: 1.4em;
 }
 
 /* ------------------------------------

--- a/style.css
+++ b/style.css
@@ -412,15 +412,32 @@ section.coc {
 .markdown blockquote,
 .section_note {
   margin-block: 2em;
-  width: calc(100% + 4em);
-  translate: -2em;
+  width: calc(100% + 1em);
+  translate: -0.5em;
   margin-inline: 0;
   background-color: #F1F1F1;
   font-size: 16px;
-  padding: 2em;
+  padding: 1em 1.5em;
   border-radius: 10px;
 }
 
 .markdown ul {
-  padding: 2em 2em 2em 55px;
+  padding: 1em 1.5em 1em 2em;
+}
+
+
+@media all and (min-width: 640px) {
+
+  .markdown ul,
+  .markdown blockquote,
+  .section_note {
+    width: calc(100% + 4em);
+    translate: -2em;
+    padding: 2em;
+  }
+
+  .markdown ul {
+    padding: 2em 2em 2em 55px;
+  }
+
 }

--- a/style.css
+++ b/style.css
@@ -3,19 +3,18 @@
 :root {
   --navbar-height: 72px;
 
-  --serif-W3: "Hiragino Mincho ProN W3", "ヒラギノ明朝 ProN W3", "Hiragino Mincho ProN", "游明朝", YuMincho, "HG明朝E", "ＭＳ Ｐ明朝", "ＭＳ 明朝", serif;
-  --serif-W6: "Hiragino Mincho ProN W6", "ヒラギノ明朝 ProN W6", "Hiragino Mincho ProN", "游明朝", YuMincho, "HG明朝E", "ＭＳ Ｐ明朝", "ＭＳ 明朝", serif;
+  --serif: "Hiragino Mincho ProN", "ヒラギノ明朝 ProN", "Hiragino Mincho ProN", "游明朝", YuMincho, "HG明朝E", "ＭＳ Ｐ明朝", "ＭＳ 明朝", serif;
   --serif-logo: "游明朝", "Yu Mincho", "游明朝体", "YuMincho", "ヒラギノ明朝 Pro W3", "Hiragino Mincho Pro", "HiraMinProN-W3", "HGS明朝E", "ＭＳ Ｐ明朝", "MS PMincho", serif;
 
   /* [2024年に最適なfont-familyの書き方](https://ics.media/entry/200317/) */
-  --sans-serif-W3: "Helvetica Neue", Arial, "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif;
+  --sans-serif: "Helvetica Neue", Arial, "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif;
 
   --color-primary: 16 40 48;
   --color-on-primary: 240 240 230;
   --color-accent: 233 30 99;
 
   font-size: 12pt;
-  font-family: var(--serif-W3);
+  font-family: var(--serif);
 }
 
 * {
@@ -79,7 +78,7 @@ Markdown
 
 .markdown {
   max-width: 32.5em;
-  font-family: var(--sans-serif-W3);
+  font-family: var(--sans-serif);
 }
 
 .markdown>* {
@@ -100,7 +99,7 @@ Markdown
 
 .markdown p,
 .markdown ul {
-  font-family: var(--serif-W3);
+  font-family: var(--serif);
   letter-spacing: 0.01em;
   line-height: 1.75;
 }
@@ -264,7 +263,8 @@ section>h2 {
 .prose h3 {
   margin-top: 1.6em;
   margin-bottom: 0.6em;
-  font-family: var(--serif-W6);
+  font-family: var(--serif);
+  font-weight: bold;
 }
 
 .map {
@@ -348,10 +348,11 @@ li.event>p {
 .sponsors h3 {
   margin: 0;
   padding-block: 2rem 0.5rem;
-  font-family: var(--serif-W3);
+  font-family: var(--serif);
   text-align: center;
   line-height: 2.25rem;
   font-size: 1.875rem;
+  font-weight: normal;
 }
 
 .sponsors p {
@@ -360,7 +361,8 @@ li.event>p {
 
 .people>h3 {
   text-align: center;
-  font-family: var(--serif-W6);
+  font-family: var(--serif);
+  font-weight: bold;
 }
 
 .people ul {

--- a/style.css
+++ b/style.css
@@ -354,11 +354,6 @@ li.event>p {
 /* ------------------------------------
 Markdown
 ------------------------------------ */
-
-section.coc {
-  padding-block: 3rem;
-}
-
 .markdown>* {
   margin-block: 1.75em;
 }
@@ -376,6 +371,25 @@ section.coc {
   font-weight: bold;
 }
 
+.markdown li {
+  padding-left: 0.3em;
+}
+
+.markdown li+li {
+  margin-top: 0.25em;
+}
+
+.markdown li::marker {
+  font-size: 1.4em;
+}
+
+/* ------------------------------------
+行動規範
+------------------------------------ */
+
+section.coc {
+  padding-block: 3rem;
+}
 
 .section_figure {
   margin-inline: 0;
@@ -393,30 +407,19 @@ section.coc {
 .markdown ul,
 .markdown blockquote,
 .section_note {
+  margin-block: 2em;
+  width: calc(100% + 4em);
+  translate: -2em;
   margin-inline: 0;
   background-color: #F1F1F1;
-  font-weight: bold;
-  line-height: 26px;
+  line-height: 1.75;
   font-size: 16px;
-  letter-spacing: 0.1em;
-  padding: 40px;
+  letter-spacing: 0.05em;
+  padding: 2em;
+  border-radius: 10px;
 }
 
-.markdown li {
-  padding-left: 22px;
-  position: relative;
-  margin-bottom: 5px;
-  list-style: none;
-}
 
-.markdown li::before {
-  content: "";
-  display: block;
-  width: 6px;
-  height: 6px;
-  background: #000000;
-  border-radius: 3px;
-  position: absolute;
-  top: 11px;
-  left: 0;
+.markdown ul {
+  padding: 2em 2em 2em 55px;
 }

--- a/style.css
+++ b/style.css
@@ -81,7 +81,7 @@ Markdown
 }
 
 .markdown>* {
-  margin-block: 1.75em;
+  margin-block: 1.5em;
 }
 
 .markdown>:first-child {
@@ -263,7 +263,6 @@ section>h2 {
   margin-top: 1.6em;
   margin-bottom: 0.6em;
   font-family: "Hiragino Mincho ProN W6", "ヒラギノ明朝 ProN W6", "Hiragino Mincho ProN", "游明朝", YuMincho, "HG明朝E", "ＭＳ Ｐ明朝", "ＭＳ 明朝", serif;
-  font-weight: bold;
 }
 
 .map {
@@ -324,7 +323,6 @@ li.event>h3 {
   grid-row: 2;
   margin-block: 0;
   font-size: 1.125rem;
-  font-weight: 700;
 }
 
 li.event>h3.highlight {
@@ -347,11 +345,11 @@ li.event>p {
 
 .sponsors h3 {
   margin: 0;
-  padding-block: 2rem;
+  padding-block: 2rem 0.5rem;
+  font-family: "Hiragino Mincho ProN W3", "ヒラギノ明朝 ProN W3", "Hiragino Mincho ProN", "游明朝", YuMincho, "HG明朝E", "ＭＳ Ｐ明朝", "ＭＳ 明朝", serif;
   text-align: center;
   line-height: 2.25rem;
   font-size: 1.875rem;
-  font-weight: 700;
 }
 
 .sponsors p {
@@ -360,6 +358,7 @@ li.event>p {
 
 .people>h3 {
   text-align: center;
+  font-family: "Hiragino Mincho ProN W6", "ヒラギノ明朝 ProN W6", "Hiragino Mincho ProN", "游明朝", YuMincho, "HG明朝E", "ＭＳ Ｐ明朝", "ＭＳ 明朝", serif;
 }
 
 .people ul {
@@ -388,7 +387,6 @@ li.event>p {
 }
 
 .people .person>a {
-  font-weight: bold;
   color: inherit;
   text-decoration: none;
 }
@@ -408,10 +406,6 @@ section.coc {
 
 .section_movie {
   max-width: 100%;
-}
-
-.section_text a {
-  font-weight: bold;
 }
 
 .markdown ul,


### PR DESCRIPTION
主に行動規範ページに適用している Markdown 向けの標準スタイルを整備します。
一部トップページにも適用していますが、こちらはなるべく見た目の変化が小さくなるように調整しています。
（デザイン面の更新はこのPRでは実施しません）

チケット：https://github.com/orgs/fp-matsuri/projects/1/views/2?pane=issue&itemId=96299851

行動規範①
<img width="2547" alt="スクリーンショット 2025-02-11 13 40 55" src="https://github.com/user-attachments/assets/161bdf55-58ec-499e-a1bc-9e34f8ae65f3" />

行動規範②
<img width="2519" alt="スクリーンショット 2025-02-11 13 41 37" src="https://github.com/user-attachments/assets/50f4d4f3-0d61-4a46-bded-cc49630c13a9" />

トップページの変更差分
<img width="2545" alt="スクリーンショット 2025-02-11 13 40 31" src="https://github.com/user-attachments/assets/47c3c181-2d5a-4adc-9614-ba3cec554be7" />
