### PR TITLE
feat: Teamセクションの占有面積を小さくする

### DIFF
--- a/app/Route/Index.elm
+++ b/app/Route/Index.elm
@@ -254,10 +254,12 @@ teamBlock =
                 ]
     in
     block "Team"
-        [ div [ class "people" ]
+        [ div [ class "people leaders" ]
             [ h3 [] [ text "座長" ]
             , ul [] (List.map listItem staff.leader)
-            , h3 [] [ text "スタッフ" ]
+            ]
+        , div [ class "people staff" ]
+            [ h3 [] [ text "スタッフ" ]
             , ul [] (List.map listItem staff.members)
             ]
         ]

--- a/app/Route/Index.elm
+++ b/app/Route/Index.elm
@@ -246,9 +246,11 @@ teamBlock : Html msg
 teamBlock =
     let
         listItem member =
-            li [ class "person" ]
-                [ img [ src ("https://github.com/" ++ member.id ++ ".png") ] []
-                , a [ href ("https://github.com/" ++ member.id), target "_blank" ] [ text member.id ]
+            li []
+                [ a [ class "person", href ("https://github.com/" ++ member.id), target "_blank" ]
+                    [ img [ src ("https://github.com/" ++ member.id ++ ".png") ] []
+                    , text member.id
+                    ]
                 ]
     in
     block "Team"

--- a/style.css
+++ b/style.css
@@ -359,13 +359,29 @@ li.event>p {
   margin-block: 1.25rem;
 }
 
+.people {
+  display: flex;
+  flex-direction: column;
+  row-gap: 2rem;
+}
+
 .people>h3 {
+  margin: 0;
   text-align: center;
   font-family: var(--serif);
   font-weight: bold;
 }
 
+.people.leaders {
+  max-width: 800px;
+}
+
+.people.staff {
+  max-width: 1200px;
+}
+
 .people ul {
+  margin: 0;
   padding: 0;
   display: flex;
   justify-content: center;

--- a/style.css
+++ b/style.css
@@ -374,7 +374,7 @@ li.event>p {
 }
 
 .people.leaders {
-  max-width: 800px;
+  max-width: 720px;
 }
 
 .people.staff {

--- a/style.css
+++ b/style.css
@@ -360,6 +360,7 @@ li.event>p {
 }
 
 .people {
+  width: 100%;
   display: flex;
   flex-direction: column;
   row-gap: 2rem;
@@ -383,16 +384,21 @@ li.event>p {
 .people ul {
   margin: 0;
   padding: 0;
-  display: flex;
+  display: grid;
   justify-content: center;
-  flex-wrap: wrap;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   row-gap: 0.2rem;
   column-gap: 1rem;
   list-style: none;
 }
 
+@media all and (min-width: 640px) {
+  .people ul {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
+}
+
 .people a.person {
-  width: 150px;
   margin: 0;
   padding: 0.5rem;
   display: flex;
@@ -414,7 +420,6 @@ a.person:hover {
 
 @media all and (min-width: 640px) {
   .people a.person {
-    width: 200px;
     font-size: 16px;
   }
 }

--- a/style.css
+++ b/style.css
@@ -367,33 +367,54 @@ li.event>p {
 
 .people ul {
   padding: 0;
-
   display: flex;
   justify-content: center;
   flex-wrap: wrap;
+  row-gap: 0.2rem;
+  column-gap: 1rem;
+  list-style: none;
 }
 
-.people li.person {
+.people a.person {
   width: 150px;
   margin: 0;
-  padding: 0.75rem;
-  list-style: none;
-
+  padding: 0.5rem;
   display: flex;
-  flex-direction: column;
   align-items: center;
-  row-gap: 0.5rem;
+  column-gap: 0.5rem;
+  font-family: var(--sans-serif);
+  font-size: 14px;
+  text-decoration: none;
+  color: inherit;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  color: #666;
+}
+
+a.person:hover {
+  background-color: #f6f6f6;
+  border-color: #eee;
+}
+
+@media all and (min-width: 640px) {
+  .people a.person {
+    width: 200px;
+    font-size: 16px;
+  }
 }
 
 .people .person>img {
-  max-width: 100%;
-  border-radius: 100%;
+  max-width: 45px;
+  border-radius: 30%;
+  border: 1px solid hsl(0 0 0 / 0.05);
 }
 
-.people .person>a {
-  color: inherit;
-  text-decoration: none;
+@media all and (min-width: 640px) {
+  .people .person>img {
+    max-width: 60px;
+  }
 }
+
 
 /* ------------------------------------
 行動規範

--- a/style.css
+++ b/style.css
@@ -130,7 +130,7 @@ p.note::before {
 }
 
 section {
-  padding: 8rem 1.5rem 6rem;
+  padding: 8rem 20px 6rem;
 
   display: flex;
   flex-direction: column;

--- a/style.css
+++ b/style.css
@@ -426,7 +426,7 @@ a.person:hover {
 
 .people .person>img {
   max-width: 45px;
-  border-radius: 30%;
+  border-radius: 50%;
   border: 1px solid hsl(0 0 0 / 0.05);
 }
 


### PR DESCRIPTION
スポンサー募集セクションの拡充を前に、Teamセクションを簡単に調整します。
スタッフのアイコンを縮小する形でレイアウトを変更し、占有面積（高さ）を抑制します。

ここでは占有面積の縮小を優先し、簡単な検討に留めています。
実機などでの見た目の最適化は、後日別のPRで実施する見込みです。

チケット：https://github.com/orgs/fp-matsuri/projects/1?pane=issue&itemId=97347840

<img width="1313" alt="スクリーンショット 2025-02-12 21 55 45" src="https://github.com/user-attachments/assets/a4976ee6-a68c-4009-b863-df507aa1220d" />

