### PR TITLE
feat: add Google site verification meta tag

### DIFF
--- a/elm-pages.config.mjs
+++ b/elm-pages.config.mjs
@@ -6,6 +6,7 @@ export default {
     return `
 <link rel="stylesheet" href="/style.css" />
 <meta name="generator" content="elm-pages v${context.cliVersion}" />
+<meta name="google-site-verification" content="bXaLaMdmF7uQAmi3krHPyj2D-Z6Zos0Jd048QJPqhL8" />
 `;
   },
   preloadTagForFile(file) {


### PR DESCRIPTION
Google検索で関数型まつりのサイトが出てくるようにするため、Google Search Consoleに登録します。
登録のためのMeta tag追加を行いました。