### PR TITLE
feat: Team セクションをスマホで表示した際に名前とアイコンが縦に並ぶようにする

### DIFF
--- a/style.css
+++ b/style.css
@@ -386,7 +386,7 @@ li.event>p {
   padding: 0;
   display: grid;
   justify-content: center;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
   row-gap: 0.2rem;
   column-gap: 1rem;
   list-style: none;
@@ -402,6 +402,7 @@ li.event>p {
   margin: 0;
   padding: 0.5rem;
   display: flex;
+  flex-direction: column;
   align-items: center;
   column-gap: 0.5rem;
   font-family: var(--sans-serif);
@@ -421,6 +422,7 @@ a.person:hover {
 @media all and (min-width: 640px) {
   .people a.person {
     font-size: 16px;
+    flex-direction: row;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -404,7 +404,7 @@ li.event>p {
   display: flex;
   flex-direction: column;
   align-items: center;
-  column-gap: 0.5rem;
+  gap: 0.5rem;
   font-family: var(--sans-serif);
   font-size: 14px;
   text-decoration: none;


### PR DESCRIPTION
#30 で提案されていたようにスマホからの表示を調整します。

PC
![image](https://github.com/user-attachments/assets/04a90e8d-e4dc-4d3f-930c-c2ad53dce73c)

スマホ
![image](https://github.com/user-attachments/assets/52eaa9de-c6bd-4e38-9f08-add9053e1b4d)
