### PR TITLE
feat: Sponsorsセクションの位置を調整 ＆ 配色を刷新

### DIFF
--- a/app/Route/Index.elm
+++ b/app/Route/Index.elm
@@ -234,7 +234,7 @@ schedule events_ =
                         , display block
                         , width (pct 100)
                         , height (pct 100)
-                        , backgroundColor (rgb 16 40 48)
+                        , property "background-color" "var(--color-primary)"
                         ]
                     , -- タイムラインのドット部分
                       after
@@ -247,7 +247,7 @@ schedule events_ =
                         , width (px 14)
                         , height (px 14)
                         , borderRadius (pct 100)
-                        , backgroundColor (hex "FFF")
+                        , property "background-color" "var(--color-on-primary)"
                         ]
                     , firstChild
                         [ before

--- a/app/Route/Index.elm
+++ b/app/Route/Index.elm
@@ -69,8 +69,8 @@ view _ _ =
         [ hero
         , aboutSection
         , overviewSection
-        , scheduleSection
         , sponsorsSection
+        , scheduleSection
         , teamSection
         ]
     }
@@ -179,6 +179,30 @@ overviewSection =
             , attribute "referrerpolicy" "no-referrer-when-downgrade"
             ]
             []
+        ]
+
+
+sponsorsSection : Html msg
+sponsorsSection =
+    section "Sponsors"
+        [ div [ class "markdown sponsors" ]
+            [ h3 [ class "text-3xl font-bold text-center py-8" ] [ text "スポンサー募集中！" ]
+            , p []
+                [ text "関数型まつりの開催には、みなさまのサポートが必要です！現在、イベントを支援していただけるスポンサー企業を募集しています。関数型プログラミングのコミュニティを一緒に盛り上げていきたいという企業のみなさま、ぜひご検討ください。"
+                ]
+            , p []
+                [ text "スポンサープランの詳細は "
+                , a [ href "https://docs.google.com/presentation/d/1zMj4lBBr9ru6oAQEUJ01jrzl9hqX1ajs0zdb-73ngto/edit?usp=sharing", Attributes.target "_blank" ] [ text "スポンサーシップのご案内" ]
+                , text " よりご確認いただけます。スポンサーには"
+                , a [ href "https://scalajp.notion.site/d5f10ec973fb4e779d96330d13b75e78", Attributes.target "_blank" ] [ text "お申し込みフォーム" ]
+                , text " からお申し込みいただけます。"
+                ]
+            , p []
+                [ text "ご不明点などありましたら、ぜひ"
+                , a [ href "https://scalajp.notion.site/19c6d12253aa8068958ee110dbe8d38d" ] [ text "お問い合わせフォーム" ]
+                , text "よりお気軽にお問い合わせください。"
+                ]
+            ]
         ]
 
 
@@ -321,30 +345,6 @@ events =
       , highlight = True
       }
     ]
-
-
-sponsorsSection : Html msg
-sponsorsSection =
-    section "Sponsors"
-        [ div [ class "markdown sponsors" ]
-            [ h3 [ class "text-3xl font-bold text-center py-8" ] [ text "スポンサー募集中！" ]
-            , p []
-                [ text "関数型まつりの開催には、みなさまのサポートが必要です！現在、イベントを支援していただけるスポンサー企業を募集しています。関数型プログラミングのコミュニティを一緒に盛り上げていきたいという企業のみなさま、ぜひご検討ください。"
-                ]
-            , p []
-                [ text "スポンサープランの詳細は "
-                , a [ href "https://docs.google.com/presentation/d/1zMj4lBBr9ru6oAQEUJ01jrzl9hqX1ajs0zdb-73ngto/edit?usp=sharing", Attributes.target "_blank" ] [ text "スポンサーシップのご案内" ]
-                , text " よりご確認いただけます。スポンサーには"
-                , a [ href "https://scalajp.notion.site/d5f10ec973fb4e779d96330d13b75e78", Attributes.target "_blank" ] [ text "お申し込みフォーム" ]
-                , text " からお申し込みいただけます。"
-                ]
-            , p []
-                [ text "ご不明点などありましたら、ぜひ"
-                , a [ href "https://scalajp.notion.site/19c6d12253aa8068958ee110dbe8d38d" ] [ text "お問い合わせフォーム" ]
-                , text "よりお気軽にお問い合わせください。"
-                ]
-            ]
-        ]
 
 
 teamSection : Html msg

--- a/app/Route/Index.elm
+++ b/app/Route/Index.elm
@@ -326,9 +326,7 @@ type alias Event msg =
 
 events : List (Event msg)
 events =
-    [ { label =
-            a [ href "https://fortee.jp/2025fp-matsuri/speaker/proposal/cfp", Attributes.target "_blank" ]
-                [ text "セッション応募開始" ]
+    [ { label = text "セッション応募開始"
       , at = "2025年1月20日"
       , highlight = False
       }

--- a/app/Route/Index.elm
+++ b/app/Route/Index.elm
@@ -137,7 +137,7 @@ links =
 aboutSection : Html msg
 aboutSection =
     section "About"
-        [ div [ class "markdown" ]
+        [ div [ class "markdown about" ]
             [ p [] [ text "関数型プログラミングのカンファレンス「関数型まつり」を開催します！" ]
             , p []
                 [ text "関数型プログラミングはメジャーな言語・フレームワークに取り入れられ、広く使われるようになりました。"

--- a/app/Route/Index.elm
+++ b/app/Route/Index.elm
@@ -162,7 +162,7 @@ overviewSection =
                 ]
     in
     section "Overview"
-        [ div [ class "markdown prose" ]
+        [ div [ class "markdown overview" ]
             [ item "Dates"
                 "2025.6.14(土)〜15(日)"
             , item "Place"
@@ -271,6 +271,7 @@ schedule events_ =
                         , gridRow "2"
                         , marginBlock zero
                         , fontSize (rem 1.125)
+                        , fontWeight normal
                         , withClass "highlight"
                             [ fontSize (rem 1.875) ]
                         ]

--- a/style.css
+++ b/style.css
@@ -9,9 +9,11 @@
   /* [2024年に最適なfont-familyの書き方](https://ics.media/entry/200317/) */
   --sans-serif: "Helvetica Neue", Arial, "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif;
 
-  --color-primary: 16 40 48;
+  --color-primary: hsl(226 49% 23%);
   --color-on-primary: 240 240 230;
-  --color-accent: 233 30 99;
+  --color-accent: hsl(4 58% 58%);
+
+  --color-grey095: hsl(226 10% 95%);
 
   font-size: 12pt;
   font-family: var(--serif);
@@ -128,6 +130,12 @@ section {
   row-gap: 2.25rem;
 }
 
+section:has(.sponsors) {
+  background-color: var(--color-grey095);
+  color: var(--color-primary);
+}
+
+
 
 section>h2 {
   margin: 0;
@@ -146,7 +154,7 @@ section>h2 {
   display: grid;
   grid-template-rows: 1fr auto 4rem auto 1fr auto;
   place-items: center;
-  background-color: hsl(226, 49%, 23%);
+  background-color: var(--color-primary);
   color: rgb(243, 244, 246);
 }
 
@@ -278,9 +286,8 @@ section>h2 {
 
 .sponsors {
   padding-inline: 2rem;
-  border: 1px solid;
   border-radius: 0.75rem;
-  border-color: #000;
+  background-color: white;
 }
 
 .sponsors h3 {
@@ -295,6 +302,10 @@ section>h2 {
 
 .sponsors p {
   margin-block: 1.25rem;
+}
+
+.sponsors a {
+  color: var(--color-accent);
 }
 
 .people {

--- a/style.css
+++ b/style.css
@@ -9,6 +9,8 @@
   /* [2024年に最適なfont-familyの書き方](https://ics.media/entry/200317/) */
   --sans-serif: "Helvetica Neue", Arial, "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif;
 
+  --montserrat-sans: montserrat, sans-serif;
+
   --color-primary: hsl(226 49% 23%);
   --color-on-primary: white;
   --color-accent: hsl(4 58% 58%);
@@ -16,7 +18,7 @@
   --color-grey095: hsl(226 10% 95%);
 
   font-size: 12pt;
-  font-family: var(--serif);
+  font-family: var(--sans-serif);
 }
 
 * {
@@ -82,7 +84,6 @@ Markdown
 
 .markdown {
   max-width: 32.5em;
-  font-family: var(--sans-serif);
 }
 
 .markdown>* {
@@ -103,7 +104,6 @@ Markdown
 
 .markdown p,
 .markdown ul {
-  font-family: var(--serif);
   letter-spacing: 0.01em;
   line-height: 1.75;
 }
@@ -143,7 +143,7 @@ section:has(.people) {
 
 section>h2 {
   margin: 0;
-  font-family: montserrat, sans-serif;
+  font-family: var(--montserrat-sans);
   font-optical-sizing: auto;
   line-height: 1;
   font-size: 3rem;
@@ -196,7 +196,7 @@ section>h2 {
 }
 
 .hero-main>.date {
-  font-family: montserrat, sans-serif;
+  font-family: var(--montserrat-sans);
   font-size: 1rem;
   font-weight: 300;
 }
@@ -272,15 +272,15 @@ section>h2 {
   height: 100%;
 }
 
-.prose {
+.overview {
   width: 100%;
 }
 
-.prose h3 {
+.overview h3 {
   margin-top: 1.6em;
   margin-bottom: 0.6em;
-  font-family: var(--serif);
-  font-weight: bold;
+  font-family: var(--montserrat-sans);
+  font-weight: normal
 }
 
 .map {
@@ -296,7 +296,6 @@ section>h2 {
 .sponsors h3 {
   margin: 0;
   padding-block: 2rem 0.5rem;
-  font-family: var(--serif);
   text-align: center;
   line-height: 2.25rem;
   font-size: 1.875rem;
@@ -317,8 +316,7 @@ section>h2 {
 .people>h3 {
   margin: 0;
   text-align: center;
-  font-family: var(--serif);
-  font-weight: bold;
+  font-weight: normal;
 }
 
 .people.leaders {
@@ -352,7 +350,6 @@ section>h2 {
   flex-direction: column;
   align-items: center;
   gap: 0.5rem;
-  font-family: var(--sans-serif);
   font-size: 14px;
   text-decoration: none;
   color: inherit;

--- a/style.css
+++ b/style.css
@@ -28,6 +28,10 @@ body {
   color: var(--color-primary);
 }
 
+a {
+  color: var(--color-accent);
+}
+
 /* ------------------------------------
 ページ共通
 ------------------------------------ */
@@ -300,10 +304,6 @@ section>h2 {
 
 .sponsors p {
   margin-block: 1.25rem;
-}
-
-.sponsors a {
-  color: var(--color-accent);
 }
 
 .people {

--- a/style.css
+++ b/style.css
@@ -10,7 +10,7 @@
   --sans-serif: "Helvetica Neue", Arial, "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif;
 
   --color-primary: hsl(226 49% 23%);
-  --color-on-primary: 240 240 230;
+  --color-on-primary: white;
   --color-accent: hsl(4 58% 58%);
 
   --color-grey095: hsl(226 10% 95%);
@@ -25,6 +25,7 @@
 
 body {
   margin: 0;
+  color: var(--color-primary);
 }
 
 /* ------------------------------------
@@ -70,7 +71,6 @@ body {
 .site-footer {
   padding: 2rem;
   text-align: center;
-  color: rgb(51 65 85);
 }
 
 /* ------------------------------------
@@ -132,7 +132,6 @@ section {
 
 section:has(.sponsors) {
   background-color: var(--color-grey095);
-  color: var(--color-primary);
 }
 
 
@@ -155,7 +154,7 @@ section>h2 {
   grid-template-rows: 1fr auto 4rem auto 1fr auto;
   place-items: center;
   background-color: var(--color-primary);
-  color: rgb(243, 244, 246);
+  color: var(--color-on-primary);
 }
 
 .hero>.hero-main {
@@ -195,7 +194,6 @@ section>h2 {
   font-family: montserrat, sans-serif;
   font-size: 1rem;
   font-weight: 300;
-  color: rgb(209, 213, 219);
 }
 
 @media all and (min-width: 640px) {
@@ -359,7 +357,6 @@ section>h2 {
   color: inherit;
   border-radius: 10px;
   border: 1px solid transparent;
-  color: #666;
 }
 
 a.person:hover {

--- a/style.css
+++ b/style.css
@@ -350,6 +350,7 @@ section>h2 {
   flex-direction: column;
   align-items: center;
   gap: 0.5rem;
+  text-align: center;
   font-size: 14px;
   text-decoration: none;
   color: inherit;

--- a/style.css
+++ b/style.css
@@ -65,9 +65,8 @@ a {
 }
 
 .site-header>nav>a {
-  display: block;
+  display: inline-block;
   padding: 0.75rem 0.5rem;
-  font-weight: 600;
   text-decoration: inherit;
   color: inherit;
 }

--- a/style.css
+++ b/style.css
@@ -133,7 +133,9 @@ section {
   row-gap: 2.25rem;
 }
 
-section:has(.sponsors) {
+section:has(.about),
+section:has(.sponsors),
+section:has(.people) {
   background-color: var(--color-grey095);
 }
 
@@ -359,8 +361,8 @@ section>h2 {
 }
 
 a.person:hover {
-  background-color: #f6f6f6;
-  border-color: #eee;
+  background-color: #f9f9f9;
+  border-color: #ddd;
 }
 
 .people .person>img {

--- a/style.css
+++ b/style.css
@@ -394,7 +394,7 @@ section.coc {
   width: calc(100% + 1em);
   translate: -0.5em;
   margin-inline: 0;
-  background-color: #F1F1F1;
+  background-color: var(--color-grey095);
   font-size: 16px;
   padding: 1em 1.5em;
   border-radius: 10px;

--- a/style.css
+++ b/style.css
@@ -222,7 +222,7 @@ section>h2 {
   text-decoration: none;
   white-space: nowrap;
   border-radius: 6px;
-  background: rgb(var(--color-accent));
+  background: rgb(233 30 99);
   color: inherit;
 }
 


### PR DESCRIPTION
https://scalamatsuri.slack.com/archives/C07BETUT5V1/p1742340401894749 のフィードバックを受けて調整しました。

3/22追記：Sponsorsセクション以外の配色およびフォント指定の変更も併せて変更しました。
- 参考：[Figma](https://www.figma.com/design/cpCoEPjZNHZdV3Z9cGkfDr/Web%E3%82%B5%E3%82%A4%E3%83%88?node-id=1-25&t=UcWMQhjqXRMivziy-4)

![localhost_1234_](https://github.com/user-attachments/assets/e5829ef8-c4ae-4455-8b20-2840d59a2295)
