### PR TITLE
feat: add initial configuration files for linter, formatter and testing framework

### DIFF
--- a/elm-review.json
+++ b/elm-review.json
@@ -1,6 +1,0 @@
-{
-  "rules": {
-    "elm-community/no-unused-imports": "warn",
-    "elm-community/no-unused-exposing": "warn"
-  }
-}

--- a/elm-review.json
+++ b/elm-review.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "elm-community/no-unused-imports": "warn",
+    "elm-community/no-unused-exposing": "warn"
+  }
+}

--- a/elm.json
+++ b/elm.json
@@ -8,9 +8,6 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "avh4/elm-color": "1.0.0",
-            "danfishgold/base64-bytes": "1.1.0",
-            "danyx23/elm-mimetype": "4.0.1",
             "dillonkearns/elm-bcp47-language-tag": "2.0.0",
             "dillonkearns/elm-form": "3.0.1",
             "dillonkearns/elm-markdown": "7.0.1",
@@ -22,47 +19,48 @@
             "elm/html": "1.0.0",
             "elm/http": "2.0.0",
             "elm/json": "1.1.3",
-            "elm/parser": "1.1.0",
-            "elm/regex": "1.0.0",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
+            "rtfeldman/elm-css": "18.0.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
+        },
+        "indirect": {
+            "Chadtech/elm-bool-extra": "2.4.2",
+            "avh4/elm-color": "1.0.0",
+            "billstclair/elm-xml-eeue56": "2.1.0",
+            "danfishgold/base64-bytes": "1.1.0",
+            "danyx23/elm-mimetype": "4.0.1",
+            "dillonkearns/elm-cli-options-parser": "3.2.0",
+            "dillonkearns/elm-date-or-date-time": "2.0.0",
+            "elm/file": "1.0.5",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
             "elm/virtual-dom": "1.0.3",
-            "elm-community/dict-extra": "2.4.0",
+            "elm-community/basics-extra": "4.1.0",
             "elm-community/list-extra": "8.7.0",
-            "elm-community/result-extra": "2.4.0",
+            "elm-community/maybe-extra": "5.3.0",
+            "fredcy/elm-parseint": "2.0.1",
             "jluckyiv/elm-utc-date-strings": "1.0.0",
             "justinmimbs/date": "4.1.0",
             "mdgriffith/elm-codegen": "5.2.0",
             "miniBill/elm-codec": "2.2.0",
+            "miniBill/elm-unicode": "1.1.1",
             "noahzgordon/elm-color-extra": "1.0.2",
             "robinheghan/fnv1a": "1.0.0",
-            "rtfeldman/elm-css": "18.0.0",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.4",
-            "the-sett/elm-syntax-dsl": "6.0.3",
-            "turboMaCk/non-empty-list-alias": "1.4.0",
-            "vito/elm-ansi": "10.0.1"
-        },
-        "indirect": {
-            "Chadtech/elm-bool-extra": "2.4.2",
-            "billstclair/elm-xml-eeue56": "2.1.0",
-            "dillonkearns/elm-cli-options-parser": "3.2.0",
-            "dillonkearns/elm-date-or-date-time": "2.0.0",
-            "elm/file": "1.0.5",
-            "elm/random": "1.0.0",
-            "elm-community/basics-extra": "4.1.0",
-            "elm-community/maybe-extra": "5.3.0",
-            "fredcy/elm-parseint": "2.0.1",
-            "miniBill/elm-unicode": "1.1.1",
             "robinheghan/murmur3": "1.0.0",
             "rtfeldman/elm-hex": "1.0.0",
             "stil4m/elm-syntax": "7.3.8",
             "stil4m/structured-writer": "1.0.3",
             "the-sett/elm-pretty-printer": "3.1.0",
+            "the-sett/elm-syntax-dsl": "6.0.3",
             "wolfadex/elm-ansi": "3.0.0"
         }
     },
     "test-dependencies": {
-        "direct": {},
+        "direct": {
+            "elm-explorations/test": "2.2.0"
+        },
         "indirect": {}
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "elm-format": "^0.8.7",
         "elm-optimize-level-2": "^0.3.5",
         "elm-pages": "3.0.19",
-        "elm-review": "^2.12.0",
+        "elm-review": "^2.13.2",
+        "elm-test": "^0.19.1-revision15",
         "lamdera": "^0.19.1-1.3.2",
         "svgo": "^3.3.2",
         "vite": "^6.0.6"
@@ -1478,16 +1479,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2264,29 +2255,6 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
-    "node_modules/dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/dir-glob/node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
@@ -2512,7 +2480,6 @@
       "integrity": "sha512-sVzFXfWnb+6rzXK+q3e3Ccgr6/uS5mFbFk1VSmigC+x2XZ28QycAa7lS8owl009ALPhRQk+pZ95Eq5ANjpEZsQ==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "BSD-3-Clause",
       "bin": {
         "elm-format": "bin/elm-format"
       },
@@ -2598,31 +2565,27 @@
       }
     },
     "node_modules/elm-review": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/elm-review/-/elm-review-2.12.0.tgz",
-      "integrity": "sha512-so+G1hvCV85A63sQQzEhCNFNYyQVWDexXrz0TNEYg3/IIGHzN1bcRN+W4KJSvvFcmfEImzMSJ9AN20bvemU+4Q==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/elm-review/-/elm-review-2.13.2.tgz",
+      "integrity": "sha512-kI34BQ/EN1NC4KUcdZWAGNbaxWmR80kqJQRjT1ZmC0AyZRiJqdylhANucyzhPKEz60VGAkqau5axpySWXbdPLg==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "chalk": "^4.0.0",
         "chokidar": "^3.5.2",
         "cross-spawn": "^7.0.3",
-        "elm-solve-deps-wasm": "^1.0.2",
+        "elm-solve-deps-wasm": "^1.0.2 || ^2.0.0",
         "fastest-levenshtein": "^1.0.16",
-        "find-up": "^4.1.0",
+        "find-up": "^4.1.0 || ^5.0.0",
         "folder-hash": "^3.3.0",
-        "fs-extra": "^9.0.0",
-        "glob": "^10.2.6",
-        "globby": "^13.2.2",
         "got": "^11.8.5",
         "graceful-fs": "^4.2.11",
         "minimist": "^1.2.6",
         "ora": "^5.4.0",
         "path-key": "^3.1.1",
         "prompts": "^2.2.1",
-        "rimraf": "^5.0.0",
         "strip-ansi": "^6.0.0",
         "terminal-link": "^2.1.1",
+        "tinyglobby": "^0.2.10",
         "which": "^2.0.2",
         "wrap-ansi": "^7.0.0"
       },
@@ -2630,20 +2593,10 @@
         "elm-review": "bin/elm-review"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": "14 >=14.21 || 16 >=16.20 || 18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/jfmengels"
-      }
-    },
-    "node_modules/elm-review/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/elm-review/node_modules/chokidar": {
@@ -2671,85 +2624,12 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/elm-review/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/elm-review/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/elm-review/node_modules/globby": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
-      "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.3.0",
-        "ignore": "^5.2.4",
-        "merge2": "^1.4.1",
-        "slash": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/elm-review/node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/elm-review/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/elm-review/node_modules/readdirp": {
       "version": "3.6.0",
@@ -2762,35 +2642,6 @@
       },
       "engines": {
         "node": ">=8.10.0"
-      }
-    },
-    "node_modules/elm-review/node_modules/rimraf": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
-      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^10.3.7"
-      },
-      "bin": {
-        "rimraf": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/elm-review/node_modules/slash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/elm-review/node_modules/which": {
@@ -2815,6 +2666,96 @@
       "integrity": "sha512-qnwo7RO9IO7jd9SLHvIy0rSOEIlc/tNMTE9Cras0kl+b161PVidW4FvXo0MtXU8GAKi/2s/HYvhcnpR/NNQ1zw==",
       "dev": true,
       "license": "MPL-2.0"
+    },
+    "node_modules/elm-test": {
+      "version": "0.19.1-revision15",
+      "resolved": "https://registry.npmjs.org/elm-test/-/elm-test-0.19.1-revision15.tgz",
+      "integrity": "sha512-QusEZmlctM4VePiwemfxwcDrhDHfHXuXau3SedRwWuBBnPQK3/WjMUzULWSbTCYHIj3DgkA84Co+V/nE0161cg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "chokidar": "^3.5.3",
+        "commander": "^9.4.1",
+        "cross-spawn": "^7.0.6",
+        "elm-solve-deps-wasm": "^1.0.2 || ^2.0.0",
+        "graceful-fs": "^4.2.10",
+        "split": "^1.0.1",
+        "tinyglobby": "^0.2.10",
+        "which": "^2.0.2",
+        "xmlbuilder": "^15.1.1"
+      },
+      "bin": {
+        "elm-test": "bin/elm-test"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/elm-test/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/elm-test/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/elm-test/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/elm-test/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/elm-test/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -6335,6 +6276,18 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -6637,6 +6590,54 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
+      "integrity": "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.4.3",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
+      "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
+      "dev": true,
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/tmp": {
       "version": "0.0.33",
@@ -7007,6 +7008,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -4,14 +4,20 @@
   "type": "module",
   "scripts": {
     "start": "elm-pages dev",
-    "build": "elm-pages build"
+    "build": "elm-pages build",
+    "format": "elm-format --yes .",
+    "validate": "elm-format --yes --validate .",
+    "test": "elm-test",
+    "lint": "elm-review",
+    "fix": "elm-review --fix && elm-format --yes ."
   },
   "devDependencies": {
     "elm": "^0.19.1-6",
     "elm-format": "^0.8.7",
     "elm-optimize-level-2": "^0.3.5",
     "elm-pages": "3.0.19",
-    "elm-review": "^2.12.0",
+    "elm-review": "^2.13.2",
+    "elm-test": "^0.19.1-revision15",
     "lamdera": "^0.19.1-1.3.2",
     "svgo": "^3.3.2",
     "vite": "^6.0.6"

--- a/review/elm.json
+++ b/review/elm.json
@@ -8,7 +8,8 @@
         "direct": {
             "elm/core": "1.0.5",
             "jfmengels/elm-review": "2.15.1",
-            "stil4m/elm-syntax": "7.3.8"
+            "stil4m/elm-syntax": "7.3.8",
+            "jfmengels/elm-review-unused": "1.2.4"
         },
         "indirect": {
             "elm/bytes": "1.0.8",

--- a/review/elm.json
+++ b/review/elm.json
@@ -1,0 +1,34 @@
+{
+    "type": "application",
+    "source-directories": [
+        "src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/core": "1.0.5",
+            "jfmengels/elm-review": "2.15.1",
+            "stil4m/elm-syntax": "7.3.8"
+        },
+        "indirect": {
+            "elm/bytes": "1.0.8",
+            "elm/html": "1.0.0",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/project-metadata-utils": "1.0.2",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0",
+            "elm/virtual-dom": "1.0.3",
+            "elm-explorations/test": "2.2.0",
+            "rtfeldman/elm-hex": "1.0.0",
+            "stil4m/structured-writer": "1.0.3"
+        }
+    },
+    "test-dependencies": {
+        "direct": {
+            "elm-explorations/test": "2.2.0"
+        },
+        "indirect": {}
+    }
+}

--- a/review/src/ReviewConfig.elm
+++ b/review/src/ReviewConfig.elm
@@ -1,0 +1,19 @@
+module ReviewConfig exposing (config)
+
+{-| Do not rename the ReviewConfig module or the config function, because
+`elm-review` will look for these.
+
+To add packages that contain rules, add them to this review project using
+
+    `elm install author/packagename`
+
+when inside the directory containing this file.
+
+-}
+
+import Review.Rule exposing (Rule)
+
+
+config : List Rule
+config =
+    []

--- a/review/src/ReviewConfig.elm
+++ b/review/src/ReviewConfig.elm
@@ -11,9 +11,10 @@ when inside the directory containing this file.
 
 -}
 
+import NoUnused.Dependencies
 import Review.Rule exposing (Rule)
 
 
 config : List Rule
 config =
-    []
+    [ NoUnused.Dependencies.rule ]

--- a/tests/Example.elm
+++ b/tests/Example.elm
@@ -1,0 +1,10 @@
+module Example exposing (..)
+
+import Expect exposing (Expectation)
+import Fuzz exposing (Fuzzer, int, list, string)
+import Test exposing (..)
+
+
+suite : Test
+suite =
+    todo "Implement our first test. See https://package.elm-lang.org/packages/elm-explorations/test/latest for how to do this!"


### PR DESCRIPTION
## Description

Elmでの開発に使う、Linter、Formatter、testのツールを入れました。

Linter: elm-review
Formatter: elm-format
Testing framework: elm-test

elm-formatのRuleは現状は空にしております。（一気に適用すると、Diffがすごくなりそうなので）
testも現状はからの状態です。