### PR TITLE
feat: Vertically align icon and name

### DIFF
--- a/style.css
+++ b/style.css
@@ -326,13 +326,12 @@ section>h2 {
   justify-content: center;
   grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
   row-gap: 0.2rem;
-  column-gap: 1rem;
   list-style: none;
 }
 
 @media all and (min-width: 640px) {
   .people ul {
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -357,13 +357,6 @@ a.person:hover {
   border-color: #eee;
 }
 
-@media all and (min-width: 640px) {
-  .people a.person {
-    font-size: 16px;
-    flex-direction: row;
-  }
-}
-
 .people .person>img {
   max-width: 45px;
   border-radius: 50%;

--- a/style.css
+++ b/style.css
@@ -357,15 +357,9 @@ a.person:hover {
 }
 
 .people .person>img {
-  max-width: 45px;
+  max-width: 50px;
   border-radius: 50%;
   border: 1px solid hsl(0 0 0 / 0.05);
-}
-
-@media all and (min-width: 640px) {
-  .people .person>img {
-    max-width: 60px;
-  }
 }
 
 


### PR DESCRIPTION
## 実施した変更

- person のアイコンと名前が、画面幅に依らず縦に並ぶように変更した
- person の名前が、画面幅に依らず 14pt になるように変更した

## デザイン仕様

Figma: https://www.figma.com/design/cpCoEPjZNHZdV3Z9cGkfDr

## 検証

Figma に掲載されている幅 390px と 1440px でそれぞれ検証した

### 幅390px

- アイコンと名前が縦に並んでいる
- フォントが 14pt

<img width="922" alt="Screenshot 2025-03-21 at 21 26 23" src="https://github.com/user-attachments/assets/4d8d459a-d7a2-4bf7-9bcd-095c240136cf" />


### 幅1440px

- アイコンと名前が縦に並んでいる
- フォントが 14pt

<img width="910" alt="Screenshot 2025-03-21 at 21 26 48" src="https://github.com/user-attachments/assets/b9f3bafd-1ae1-4e50-8623-3199878a1438" />
