### PR TITLE
feat: LPのスタイルを簡易に調整

### DIFF
--- a/style.css
+++ b/style.css
@@ -130,12 +130,12 @@ Markdown
 ------------------------------------ */
 
 section {
-  padding: 8rem 20px 6rem;
+  padding: 5rem 20px;
 
   display: flex;
   flex-direction: column;
   align-items: center;
-  row-gap: 2.25rem;
+  row-gap: 3rem;
 }
 
 section:has(.about),
@@ -149,7 +149,7 @@ section > h2 {
   font-family: var(--montserrat-sans);
   font-optical-sizing: auto;
   line-height: 1;
-  font-size: 3rem;
+  font-size: 2.5rem;
   font-weight: 300;
 }
 

--- a/style.css
+++ b/style.css
@@ -154,27 +154,25 @@ section > h2 {
 }
 
 .hero {
-  height: calc(100vh - var(--navbar-height));
-  height: calc(100dvh - var(--navbar-height));
-  padding: 48px;
+  padding: 90px 40px 40px;
   display: grid;
-  grid-template-rows: 1fr auto 4rem auto 1fr auto;
+  grid-template-rows: auto auto auto;
   place-items: center;
+  row-gap: 3.5rem;
   background-color: var(--color-primary);
   color: var(--color-on-primary);
 }
 
 .hero > .hero-main {
-  grid-row: 2;
   display: grid;
-  grid-template-rows: 7.5rem auto auto;
+  grid-template-rows: 7rem auto auto;
   place-items: center;
   row-gap: 1.2rem;
 }
 
 @media all and (min-width: 640px) {
   .hero > .hero-main {
-    grid-template-rows: 12rem auto auto;
+    grid-template-rows: 9rem auto auto;
   }
 }
 
@@ -186,14 +184,13 @@ section > h2 {
   margin: 0;
   line-height: 1;
   font-family: var(--serif-logo);
-  font-size: 3rem;
+  font-size: 2.5rem;
   font-weight: inherit;
-  letter-spacing: -0.25rem;
 }
 
 @media all and (min-width: 640px) {
   .hero-main > h1 {
-    font-size: 4.5rem;
+    font-size: 3.25rem;
   }
 }
 
@@ -210,8 +207,6 @@ section > h2 {
 }
 
 .hero .announcement {
-  grid-row: 4;
-
   display: flex;
   flex-direction: column;
   row-gap: 1rem;
@@ -239,7 +234,6 @@ section > h2 {
 }
 
 .hero .links {
-  grid-row: 6;
   width: 100%;
   margin: 0;
   padding: 0;

--- a/style.css
+++ b/style.css
@@ -52,9 +52,9 @@ a {
 .site-header {
   padding: 0.75rem;
   display: grid;
-  grid-template-columns: 180px 1fr;
+  grid-template-columns: 150px 1fr;
   align-items: center;
-  column-gap: 1.5rem;
+  column-gap: 2rem;
   box-shadow: rgba(0, 0, 0, 0.1) 0px 1px 3px 0px,
     rgba(0, 0, 0, 0.1) 0px 1px 2px -1px;
 }
@@ -73,7 +73,7 @@ a {
 
 .site-header > nav > a {
   display: inline-block;
-  padding: 0.75rem 0.5rem;
+  padding: 0.5rem 0.5rem;
   text-decoration: inherit;
   color: inherit;
 }

--- a/style.css
+++ b/style.css
@@ -130,7 +130,7 @@ Markdown
 ------------------------------------ */
 
 section {
-  padding: 5rem 20px;
+  padding: 4rem 20px;
 
   display: flex;
   flex-direction: column;
@@ -149,23 +149,23 @@ section > h2 {
   font-family: var(--montserrat-sans);
   font-optical-sizing: auto;
   line-height: 1;
-  font-size: 2.5rem;
+  font-size: 2.25rem;
   font-weight: 300;
 }
 
 .hero {
-  padding: 90px 40px 40px;
+  padding: 60px 40px 40px;
   display: grid;
   grid-template-rows: auto auto auto;
   place-items: center;
-  row-gap: 3.5rem;
+  row-gap: 3rem;
   background-color: var(--color-primary);
   color: var(--color-on-primary);
 }
 
 .hero > .hero-main {
   display: grid;
-  grid-template-rows: 7rem auto auto;
+  grid-template-rows: 6rem auto auto;
   place-items: center;
   row-gap: 1.2rem;
 }
@@ -184,7 +184,7 @@ section > h2 {
   margin: 0;
   line-height: 1;
   font-family: var(--serif-logo);
-  font-size: 2.5rem;
+  font-size: 2.2rem;
   font-weight: inherit;
 }
 


### PR DESCRIPTION
今後の情報量増加に備えて、LPのスタイルを次のように調整します

- サイトヘッダーロゴをひと回り縮小
  - スマホで窮屈だったため調整
- .heroの高さを圧縮し、表示崩れを解消する
  - スマホなどでコンテンツに対して高さが足りていなかったので、コンテンツの高さ基準で調整
  - 添付画像のように下部アイコンとのギャップがなくなってしまっていたほか、さらに小さい端末では紺背景よりもはみ出していた
- セクションの基本スタイルを簡易に調整
  - 余白や見出しの大きさを少しずつ縮小し、縦方向のスクロール量を抑える

<img width="810" alt="スクリーンショット 2025-03-27 10 56 57" src="https://github.com/user-attachments/assets/7e5fd4a0-b0b6-4c41-a093-16ee5e94bfce" />

<img width="2320" alt="スクリーンショット 2025-03-27 10 55 55" src="https://github.com/user-attachments/assets/29297f48-4d23-4b62-b909-516e04befda1" />
