### PR TITLE
fix: 無効になったURLを最新化する

### DIFF
--- a/app/Route/Index.elm
+++ b/app/Route/Index.elm
@@ -94,7 +94,7 @@ hero =
                 [ div [ style "text-align" "center", style "word-break" "auto-phrase" ]
                     [ text "セッション採択結果を公開しました。" ]
                 , div [ class "buttons" ]
-                    [ a [ class "button", href "https://fortee.jp/2025fp-matsuri/proposal/all", Attributes.target "_blank" ]
+                    [ a [ class "button", href "https://fortee.jp/2025fp-matsuri/proposal/accepted", Attributes.target "_blank" ]
                         [ text "セッション一覧を見る" ]
                     ]
                 ]
@@ -162,7 +162,7 @@ newsSection =
                 ]
             ]
             [ newsItem "2025-03-30"
-                [ a [ href "https://fortee.jp/2025fp-matsuri/proposal/all", Attributes.target "_blank", rel "noopener noreferrer" ]
+                [ a [ href "https://fortee.jp/2025fp-matsuri/proposal/accepted", Attributes.target "_blank", rel "noopener noreferrer" ]
                     [ text "セッション採択結果を公開しました" ]
                 ]
             , newsItem "2025-03-02" [ text "公募セッションの応募を締め切りました" ]


### PR DESCRIPTION
forteeの段階を次に進めた影響で https://fortee.jp/2025fp-matsuri/proposal/all がリンク切れになってしまったため、採択されたトークだけが表示されるURL https://fortee.jp/2025fp-matsuri/proposal/accepted に更新します