### PR TITLE
不要なstyleを削除

### DIFF
--- a/style.css
+++ b/style.css
@@ -283,13 +283,6 @@ Overview
   font-weight: bold;
 }
 
-.overview-flex-box {
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  padding: 0 1.2em;
-}
-
 @media all and (min-width: 640px) {
   .overview-box {
     display: grid;


### PR DESCRIPTION
リネーム漏れを修正しようとしましたが、そもそもデフォルトで縦並びに配置されているので削除します

![image](https://github.com/user-attachments/assets/2c56048f-df45-4e58-a852-7475dd240287)

