### PR TITLE
fix: Order of members

### DIFF
--- a/app/Route/Index.elm
+++ b/app/Route/Index.elm
@@ -925,6 +925,7 @@ staff =
         , Member "kmizu"
         , Member "lmdexpr"
         , Member "magnolia-k"
+        , Member "omiend"
         , Member "quantumshiro"
         , Member "rabe1028"
         , Member "takezoux2"
@@ -937,7 +938,6 @@ staff =
         , Member "y047aka"
         , Member "yonta"
         , Member "yshnb"
-        , Member "omiend"
         ]
     }
 


### PR DESCRIPTION
# Why

https://www.notion.so/scalajp/Dev-1dc6d12253aa80b9adedd7e832eb296f

# What

Befor:
<img width="1800" alt="Screenshot 2025-05-13 at 15 15 35" src="https://github.com/user-attachments/assets/97639d0f-529a-40ea-aa46-ad40292bdbb5" />

After:
<img width="1800" alt="Screenshot 2025-05-13 at 15 15 05" src="https://github.com/user-attachments/assets/e8e1e275-8f17-4451-b378-7ab8662484b4" />
