### PR TITLE
feat: タグのテキストを上下中央になるように調整

### DIFF
--- a/app/Route/Schedule.elm
+++ b/app/Route/Schedule.elm
@@ -467,10 +467,11 @@ viewTag : { name : String, colorText : Css.Color, colorBackground : Css.Color } 
 viewTag tag =
     div
         [ css
-            [ display inlineBlock
-            , padding2 (px 2) (px 6)
+            [ display tableCell
+            , padding (px 5)
             , borderRadius (px 4)
             , whiteSpace noWrap
+            , lineHeight (num 1)
             , fontSize (px 12)
             , backgroundColor tag.colorBackground
             , color tag.colorText

--- a/app/Route/Schedule.elm
+++ b/app/Route/Schedule.elm
@@ -467,8 +467,7 @@ viewTag : { name : String, colorText : Css.Color, colorBackground : Css.Color } 
 viewTag tag =
     div
         [ css
-            [ display tableCell
-            , padding (px 5)
+            [ padding (px 5)
             , borderRadius (px 4)
             , whiteSpace noWrap
             , lineHeight (num 1)


### PR DESCRIPTION
タグのテキスト部分が上下中央揃えになっていない旨の指摘があったので、調整します。
https://scalamatsuri.slack.com/archives/C07SGLMRF8E/p1747833868046469

<img width="903" alt="スクリーンショット 2025-05-22 10 40 14" src="https://github.com/user-attachments/assets/9c3beed9-4ca7-4138-a58f-e67678ea095b" />
