### PR TITLE
fix: sitemap.xmlの各URL末尾にスラッシュを追加する

### DIFF
--- a/app/Api.elm
+++ b/app/Api.elm
@@ -52,8 +52,14 @@ makeSitemapEntries getStaticRoutes =
         build route =
             let
                 routeSource lastMod =
+                    let
+                        hackyTrailingSlash =
+                            -- dillonkearns/elm-sitemapでの処理で末尾の`/`が削除されるので、`//`とすることで片方を残すようにする
+                            -- https://github.com/dillonkearns/elm-sitemap/blob/ef6faa987f89ed8ec16497816e4afe1adaf2e23d/src/Path.elm#L25-L31
+                            "//"
+                    in
                     BackendTask.succeed
-                        { path = String.join "/" (Route.routeToPath route)
+                        { path = String.join "/" (Route.routeToPath route) ++ hackyTrailingSlash
                         , lastMod = Just lastMod
                         }
             in


### PR DESCRIPTION
Googleにインデックスされな問題の対処の一環で、sitemap.xmlに記載されるURLの正規化を試してみます。

現行：https://2025.fp-matsuri.org/sitemap.xml
改修後のプレビュー： https://2025fp-matsuri-lii6801wd-keitans-projects.vercel.app/sitemap.xml 