### PR TITLE
feat: スタッフ一覧のアイコンサイズを縮小する

### DIFF
--- a/app/Route/Index.elm
+++ b/app/Route/Index.elm
@@ -856,9 +856,9 @@ teamSection =
                         , displayFlex
                         , flexDirection column
                         , alignItems center
-                        , rowGap (rem 0.5)
+                        , rowGap (em 0.5)
                         , textAlign center
-                        , fontSize (px 14)
+                        , fontSize (px 10)
                         , textDecoration none
                         , color inherit
                         , borderRadius (px 10)
@@ -872,7 +872,9 @@ teamSection =
                     [ img
                         [ src ("https://github.com/" ++ member.id ++ ".png")
                         , css
-                            [ maxWidth (px 50)
+                            [ width (px 40)
+                            , height (px 40)
+                            , property "object-fit" "cover"
                             , borderRadius (pct 50)
                             , border3 (px 1) solid (hsla 0 0 0 0.05)
                             ]

--- a/app/Route/Index.elm
+++ b/app/Route/Index.elm
@@ -847,8 +847,37 @@ teamSection =
     let
         listItem member =
             li []
-                [ a [ class "person", href ("https://github.com/" ++ member.id), Attributes.target "_blank" ]
-                    [ img [ src ("https://github.com/" ++ member.id ++ ".png") ] []
+                [ a
+                    [ href ("https://github.com/" ++ member.id)
+                    , Attributes.target "_blank"
+                    , css
+                        [ margin zero
+                        , padding (rem 0.5)
+                        , displayFlex
+                        , flexDirection column
+                        , alignItems center
+                        , rowGap (rem 0.5)
+                        , textAlign center
+                        , fontSize (px 14)
+                        , textDecoration none
+                        , color inherit
+                        , borderRadius (px 10)
+                        , border3 (px 1) solid transparent
+                        , hover
+                            [ backgroundColor (hex "f9f9f9")
+                            , borderColor (hex "ddd")
+                            ]
+                        ]
+                    ]
+                    [ img
+                        [ src ("https://github.com/" ++ member.id ++ ".png")
+                        , css
+                            [ maxWidth (px 50)
+                            , borderRadius (pct 50)
+                            , border3 (px 1) solid (hsla 0 0 0 0.05)
+                            ]
+                        ]
+                        []
                     , text member.id
                     ]
                 ]

--- a/style.css
+++ b/style.css
@@ -310,32 +310,6 @@ section > h2 {
   }
 }
 
-.people a.person {
-  margin: 0;
-  padding: 0.5rem;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.5rem;
-  text-align: center;
-  font-size: 14px;
-  text-decoration: none;
-  color: inherit;
-  border-radius: 10px;
-  border: 1px solid transparent;
-}
-
-a.person:hover {
-  background-color: #f9f9f9;
-  border-color: #ddd;
-}
-
-.people .person > img {
-  max-width: 50px;
-  border-radius: 50%;
-  border: 1px solid hsl(0 0 0 / 0.05);
-}
-
 /* ------------------------------------
 行動規範
 ------------------------------------ */

--- a/style.css
+++ b/style.css
@@ -287,11 +287,11 @@ section > h2 {
 }
 
 .people.leaders {
-  max-width: 720px;
+  max-width: 600px;
 }
 
 .people.staff {
-  max-width: 1200px;
+  max-width: 799px;
 }
 
 .people ul {
@@ -299,14 +299,14 @@ section > h2 {
   padding: 0;
   display: grid;
   justify-content: center;
-  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
   row-gap: 0.2rem;
   list-style: none;
 }
 
 @media all and (min-width: 640px) {
   .people ul {
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
   }
 }
 


### PR DESCRIPTION
トップページにコンテンツが増えてきたので、相対的に優先度の低いスタッフ一覧の表示を縮小します。
応援団のアイコンと同じサイズにしました。
<img width="979" alt="スクリーンショット 2025-05-23 9 24 02" src="https://github.com/user-attachments/assets/034c0f98-8534-459a-9c06-4475ad4a8a4a" />
